### PR TITLE
Update compatibility for wagtail>=1.5

### DIFF
--- a/molo/polls/admin.py
+++ b/molo/polls/admin.py
@@ -61,6 +61,8 @@ def download_as_csv(question_admin, request, queryset):
                     choice.user, choice.answer])
 
     return response
+
+
 download_as_csv.short_description = "Download selected as csv"
 
 

--- a/molo/polls/admin.py
+++ b/molo/polls/admin.py
@@ -5,7 +5,7 @@ from django.contrib import admin
 from django.core.urlresolvers import reverse
 from django.http import HttpResponse
 from molo.polls.models import Question, Choice, FreeTextVote
-from wagtailmodeladmin.options import ModelAdmin as WagtailModelAdmin
+from wagtail.contrib.modeladmin.options import ModelAdmin as WagtailModelAdmin
 
 
 class ParentListFilter(admin.SimpleListFilter):

--- a/molo/polls/models.py
+++ b/molo/polls/models.py
@@ -83,6 +83,7 @@ class Question(TranslatablePageMixin, Page):
                     parent_article  .get_effective_extra_style_hints()
         return self.extra_style_hints
 
+
 Question.settings_panels = [
     MultiFieldPanel(
         [FieldRowPanel(

--- a/molo/polls/templates/admin/question_results.html
+++ b/molo/polls/templates/admin/question_results.html
@@ -1,5 +1,5 @@
 {% extends "wagtailadmin/base.html" %}
-{% load i18n wagtailmodeladmin_tags admin_static admin_modify %}
+{% load i18n modeladmin_tags admin_static admin_modify %}
 {% load admin_urls %}
 
 {% block titletag %}{{ view.get_meta_title }}{% endblock %}

--- a/molo/polls/tests/test_wagtail_admin.py
+++ b/molo/polls/tests/test_wagtail_admin.py
@@ -35,7 +35,7 @@ class TestQuestionResultsAdminView(TestCase, MoloTestCaseMixin):
         self.polls_index.add_child(instance=question)
 
         response = self.client.get(
-            '/admin/modeladmin/polls/question/'
+            '/admin/polls/question/'
         )
 
         self.assertContains(response, question.title)

--- a/molo/polls/wagtail_hooks.py
+++ b/molo/polls/wagtail_hooks.py
@@ -2,7 +2,7 @@ from django.conf.urls import url
 from molo.polls.admin import QuestionsModelAdmin
 from molo.polls.admin_views import QuestionResultsAdminView
 from wagtail.wagtailcore import hooks
-from wagtailmodeladmin.options import wagtailmodeladmin_register
+from wagtail.contrib.modeladmin.options import modeladmin_register
 from django.contrib.auth.models import User
 
 
@@ -14,7 +14,7 @@ def register_question_results_admin_view_url():
             name='question-results-admin'),
     ]
 
-wagtailmodeladmin_register(QuestionsModelAdmin)
+modeladmin_register(QuestionsModelAdmin)
 
 
 @hooks.register('construct_main_menu')

--- a/molo/polls/wagtail_hooks.py
+++ b/molo/polls/wagtail_hooks.py
@@ -14,6 +14,7 @@ def register_question_results_admin_view_url():
             name='question-results-admin'),
     ]
 
+
 modeladmin_register(QuestionsModelAdmin)
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-molo.core<4.0.0,>=3.7.1
+molo.core<5.0.0,>=4.0.0
 wagtailmodeladmin


### PR DESCRIPTION
Remove dependencies on wagtailmodeladmin module, which is incorporated into wagtaill>=1.5. Molo>=4 uses Wagtail>=1.8